### PR TITLE
Add ChildOrders-related API calls

### DIFF
--- a/pkg/api/v1/cancelchildorder/childorder.go
+++ b/pkg/api/v1/cancelchildorder/childorder.go
@@ -1,0 +1,36 @@
+package cancelchildorder
+
+import (
+	"encoding/json"
+	"github.com/kkohtaka/go-bitflyer/pkg/api/v1/markets"
+	"github.com/pkg/errors"
+	"net/http"
+)
+
+type Request struct {
+	ProductCode            markets.ProductCode `json:"product_code"`
+	ChildOrderId           string              `json:"child_order_id"`
+	ChildOrderAcceptanceId string              `json:"child_order_acceptance_id"`
+}
+
+type Response struct{}
+
+const (
+	APIPath = "/v1/me/cancelchildorder"
+)
+
+func (req *Request) Method() string {
+	return http.MethodPost
+}
+
+func (req *Request) Query() string {
+	return ""
+}
+
+func (req *Request) Payload() []byte {
+	body, err := json.Marshal(*req)
+	if err != nil {
+		panic(errors.Wrap(err, "json serialization error"))
+	}
+	return body
+}

--- a/pkg/api/v1/childorder/childorder.go
+++ b/pkg/api/v1/childorder/childorder.go
@@ -1,0 +1,65 @@
+package childorder
+
+import (
+	"encoding/json"
+	"github.com/kkohtaka/go-bitflyer/pkg/api/v1/markets"
+	"github.com/pkg/errors"
+	"net/http"
+	"time"
+)
+
+type Request struct {
+	ProductCode    markets.ProductCode `json:"product_code"`
+	ChildOrderType OrderType           `json:"child_order_type"`
+	Side           Side                `json:"side"`
+	Price          float64             `json:"price"`
+	Size           float64             `json:"size"`
+	MinuteToExpire time.Duration       `json:"minute_to_expire"`
+	TimeInForce    ExecutiveCondition  `json:"time_in_force"`
+}
+
+type Response struct {
+	ChildOrderAcceptanceId string `json:"child_order_acceptance_id"`
+}
+
+type OrderType string
+
+const (
+	LIMIT  OrderType = "LIMIT"
+	MARKET OrderType = "MARKET"
+)
+
+type Side string
+
+const (
+	BUY  Side = "BUY"
+	SELL Side = "SELL"
+)
+
+type ExecutiveCondition string
+
+const (
+	GTC ExecutiveCondition = "GTC"
+	IOC ExecutiveCondition = "IOC"
+	FOK ExecutiveCondition = "FOK"
+)
+
+const (
+	APIPath string = "/v1/me/sendchildorder"
+)
+
+func (req *Request) Method() string {
+	return http.MethodPost
+}
+
+func (req *Request) Query() string {
+	return ""
+}
+
+func (req *Request) Payload() []byte {
+	body, err := json.Marshal(*req)
+	if err != nil {
+		panic(errors.Wrap(err, "json serialization error"))
+	}
+	return body
+}

--- a/pkg/api/v1/childorders/childorders.go
+++ b/pkg/api/v1/childorders/childorders.go
@@ -21,11 +21,11 @@ type Request struct {
 type OrderState string
 
 const (
-	ACTIVE    OrderState = "ACTIVE"
-	COMPLETED OrderState = "COMPLETED"
-	CANCELED  OrderState = "CANCELED"
-	EXPIRED   OrderState = "EXPIRED"
-	REJECTED  OrderState = "REJECTED"
+	Active    OrderState = "ACTIVE"
+	Completed OrderState = "COMPLETED"
+	Canceled  OrderState = "CANCELED"
+	Expired   OrderState = "EXPIRED"
+	Rejected  OrderState = "REJECTED"
 )
 
 type Response []Order

--- a/pkg/api/v1/childorders/childorders.go
+++ b/pkg/api/v1/childorders/childorders.go
@@ -1,0 +1,67 @@
+package childorders
+
+import (
+	"github.com/google/go-querystring/query"
+	"github.com/kkohtaka/go-bitflyer/pkg/api/v1/markets"
+	"github.com/kkohtaka/go-bitflyer/pkg/api/v1/sendchildorder"
+	"net/http"
+	"time"
+)
+
+type Request struct {
+	ProductCode     markets.ProductCode
+	Count           int64
+	Before          int64
+	After           int64
+	ChildOrderState OrderState
+	ChildOrderId    string
+	ParentOrderId   string
+}
+
+type OrderState string
+
+const (
+	ACTIVE    OrderState = "ACTIVE"
+	COMPLETED OrderState = "COMPLETED"
+	CANCELED  OrderState = "CANCELED"
+	EXPIRED   OrderState = "EXPIRED"
+	REJECTED  OrderState = "REJECTED"
+)
+
+type Response []Order
+
+type Order struct {
+	Id                     int64                    `json:"id"`
+	ChildOrderId           string                   `json:"child_order_id"`
+	ProductCode            markets.ProductCode      `json:"product_code"`
+	Side                   sendchildorder.Side      `json:"side"`
+	ChildOrderType         sendchildorder.OrderType `json:"child_order_type"`
+	Price                  float64                  `json:"price"`
+	AveragePrice           float64                  `json:"average_price"`
+	Size                   float64                  `json:"size"`
+	ChildOrderState        OrderState               `json:"child_order_state"`
+	ExpireDate             time.Time                `json:"expire_date"`
+	ChildOrderDate         time.Time                `json:"child_order_date"`
+	ChildOrderAcceptanceId string                   `json:"child_order_acceptance_id"`
+	OutstandingSize        float64                  `json:"outstanding_size"`
+	CancelSize             float64                  `json:"cancel_size"`
+	ExecutedSize           float64                  `json:"executed_size"`
+	TotalCommission        float64                  `json:"total_commission"`
+}
+
+const (
+	APIPath = "/v1/me/getchildorders"
+)
+
+func (req *Request) Method() string {
+	return http.MethodGet
+}
+
+func (req *Request) Query() string {
+	values, _ := query.Values(req)
+	return values.Encode()
+}
+
+func (req *Request) Payload() []byte {
+	return nil
+}

--- a/pkg/api/v1/client.go
+++ b/pkg/api/v1/client.go
@@ -10,8 +10,8 @@ import (
 	"github.com/kkohtaka/go-bitflyer/pkg/api/v1/balance"
 	"github.com/kkohtaka/go-bitflyer/pkg/api/v1/bankaccounts"
 	"github.com/kkohtaka/go-bitflyer/pkg/api/v1/board"
+	"github.com/kkohtaka/go-bitflyer/pkg/api/v1/cancelchildorder"
 	"github.com/kkohtaka/go-bitflyer/pkg/api/v1/chats"
-	"github.com/kkohtaka/go-bitflyer/pkg/api/v1/childorder"
 	"github.com/kkohtaka/go-bitflyer/pkg/api/v1/coinins"
 	"github.com/kkohtaka/go-bitflyer/pkg/api/v1/coinouts"
 	"github.com/kkohtaka/go-bitflyer/pkg/api/v1/collateral"
@@ -20,6 +20,7 @@ import (
 	"github.com/kkohtaka/go-bitflyer/pkg/api/v1/health"
 	"github.com/kkohtaka/go-bitflyer/pkg/api/v1/markets"
 	"github.com/kkohtaka/go-bitflyer/pkg/api/v1/permissions"
+	"github.com/kkohtaka/go-bitflyer/pkg/api/v1/sendchildorder"
 	"github.com/kkohtaka/go-bitflyer/pkg/api/v1/ticker"
 	"github.com/pkg/errors"
 )
@@ -179,9 +180,18 @@ func (c *Client) BankAccounts(req *bankaccounts.Request) (*bankaccounts.Response
 	return &resp, nil
 }
 
-func (c *Client) SendChildOrder(req *childorder.Request) (*childorder.Response, error) {
-	var resp childorder.Response
-	err := httpclient.New().Auth(c.AuthConfig).Request(NewAPI(c, childorder.APIPath), req, &resp)
+func (c *Client) SendChildOrder(req *sendchildorder.Request) (*sendchildorder.Response, error) {
+	var resp sendchildorder.Response
+	err := httpclient.New().Auth(c.AuthConfig).Request(NewAPI(c, sendchildorder.APIPath), req, &resp)
+	if err != nil {
+		return nil, errors.Wrap(err, "send HTTP request")
+	}
+	return &resp, nil
+}
+
+func (c *Client) CancelChildOrder(req *cancelchildorder.Request) (*cancelchildorder.Response, error) {
+	var resp cancelchildorder.Response
+	err := httpclient.New().Auth(c.AuthConfig).Request(NewAPI(c, cancelchildorder.APIPath), req, &resp)
 	if err != nil {
 		return nil, errors.Wrap(err, "send HTTP request")
 	}

--- a/pkg/api/v1/client.go
+++ b/pkg/api/v1/client.go
@@ -12,6 +12,7 @@ import (
 	"github.com/kkohtaka/go-bitflyer/pkg/api/v1/board"
 	"github.com/kkohtaka/go-bitflyer/pkg/api/v1/cancelchildorder"
 	"github.com/kkohtaka/go-bitflyer/pkg/api/v1/chats"
+	"github.com/kkohtaka/go-bitflyer/pkg/api/v1/childorders"
 	"github.com/kkohtaka/go-bitflyer/pkg/api/v1/coinins"
 	"github.com/kkohtaka/go-bitflyer/pkg/api/v1/coinouts"
 	"github.com/kkohtaka/go-bitflyer/pkg/api/v1/collateral"
@@ -192,6 +193,15 @@ func (c *Client) SendChildOrder(req *sendchildorder.Request) (*sendchildorder.Re
 func (c *Client) CancelChildOrder(req *cancelchildorder.Request) (*cancelchildorder.Response, error) {
 	var resp cancelchildorder.Response
 	err := httpclient.New().Auth(c.AuthConfig).Request(NewAPI(c, cancelchildorder.APIPath), req, &resp)
+	if err != nil {
+		return nil, errors.Wrap(err, "send HTTP request")
+	}
+	return &resp, nil
+}
+
+func (c *Client) ChildOrders(req *childorders.Request) (*childorders.Response, error) {
+	var resp childorders.Response
+	err := httpclient.New().Auth(c.AuthConfig).Request(NewAPI(c, childorders.APIPath), req, &resp)
 	if err != nil {
 		return nil, errors.Wrap(err, "send HTTP request")
 	}

--- a/pkg/api/v1/client.go
+++ b/pkg/api/v1/client.go
@@ -11,6 +11,7 @@ import (
 	"github.com/kkohtaka/go-bitflyer/pkg/api/v1/bankaccounts"
 	"github.com/kkohtaka/go-bitflyer/pkg/api/v1/board"
 	"github.com/kkohtaka/go-bitflyer/pkg/api/v1/chats"
+	"github.com/kkohtaka/go-bitflyer/pkg/api/v1/childorder"
 	"github.com/kkohtaka/go-bitflyer/pkg/api/v1/coinins"
 	"github.com/kkohtaka/go-bitflyer/pkg/api/v1/coinouts"
 	"github.com/kkohtaka/go-bitflyer/pkg/api/v1/collateral"
@@ -172,6 +173,15 @@ func (c *Client) Coinouts(req *coinouts.Request) (*coinouts.Response, error) {
 func (c *Client) BankAccounts(req *bankaccounts.Request) (*bankaccounts.Response, error) {
 	var resp bankaccounts.Response
 	err := httpclient.New().Auth(c.AuthConfig).Request(NewAPI(c, bankaccounts.APIPath), req, &resp)
+	if err != nil {
+		return nil, errors.Wrap(err, "send HTTP request")
+	}
+	return &resp, nil
+}
+
+func (c *Client) SendChildOrder(req *childorder.Request) (*childorder.Response, error) {
+	var resp childorder.Response
+	err := httpclient.New().Auth(c.AuthConfig).Request(NewAPI(c, childorder.APIPath), req, &resp)
 	if err != nil {
 		return nil, errors.Wrap(err, "send HTTP request")
 	}

--- a/pkg/api/v1/sendchildorder/childorder.go
+++ b/pkg/api/v1/sendchildorder/childorder.go
@@ -1,4 +1,4 @@
-package childorder
+package sendchildorder
 
 import (
 	"encoding/json"

--- a/pkg/api/v1/sendchildorder/childorder.go
+++ b/pkg/api/v1/sendchildorder/childorder.go
@@ -5,7 +5,6 @@ import (
 	"github.com/kkohtaka/go-bitflyer/pkg/api/v1/markets"
 	"github.com/pkg/errors"
 	"net/http"
-	"time"
 )
 
 type Request struct {
@@ -14,7 +13,7 @@ type Request struct {
 	Side           Side                `json:"side"`
 	Price          float64             `json:"price"`
 	Size           float64             `json:"size"`
-	MinuteToExpire time.Duration       `json:"minute_to_expire"`
+	MinuteToExpire int64               `json:"minute_to_expire"`
 	TimeInForce    ExecutiveCondition  `json:"time_in_force"`
 }
 

--- a/pkg/api/v1/sendchildorder/childorder.go
+++ b/pkg/api/v1/sendchildorder/childorder.go
@@ -24,23 +24,23 @@ type Response struct {
 type OrderType string
 
 const (
-	LIMIT  OrderType = "LIMIT"
-	MARKET OrderType = "MARKET"
+	Limit  OrderType = "LIMIT"
+	Market OrderType = "MARKET"
 )
 
 type Side string
 
 const (
-	BUY  Side = "BUY"
-	SELL Side = "SELL"
+	Buy  Side = "BUY"
+	Sell Side = "SELL"
 )
 
 type ExecutiveCondition string
 
 const (
 	GTC ExecutiveCondition = "GTC"
-	IOC ExecutiveCondition = "IOC"
-	FOK ExecutiveCondition = "FOK"
+	IoC ExecutiveCondition = "IOC"
+	FoK ExecutiveCondition = "FOK"
 )
 
 const (


### PR DESCRIPTION
# Summary

I implemented endpoints below, please consider to merge it.

* https://lightning.bitflyer.com/docs?lang=en#send-a-new-order
* https://lightning.bitflyer.com/docs?lang=en#cancel-order
* https://lightning.bitflyer.com/docs?lang=en#list-orders

# Discussion

Package's names under `v1` api, are noun and imply only GET resources.
`sendchildorder` and `cancelchildorder` are exception of naming existing.
How to name these package?